### PR TITLE
Do not run Sonarcloud when token is not available

### DIFF
--- a/.github/workflows/main-sonarcloud.yml
+++ b/.github/workflows/main-sonarcloud.yml
@@ -19,3 +19,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        if: ${{ env.SONAR_TOKEN }}


### PR DESCRIPTION
From https://github.com/rewardenv/reward/actions/runs/5201400959/jobs/9381493794?pr=44
